### PR TITLE
Always use English locale for dates

### DIFF
--- a/docs/sphinx_deployment.mk
+++ b/docs/sphinx_deployment.mk
@@ -175,9 +175,9 @@ prepare_gh_pages_deployment:
 
 deploy_gh_pages: prepare_gh_pages_deployment
 	@echo "Deploying on github pages now..."
-	@cd $(DEPLOY_DIR); git add -A; git commit -m "docs updated at `date -u`";\
+	@cd $(DEPLOY_DIR); git add -A; git commit -m "docs updated at `LANG=en_US.utf8 date -u`";\
 		git push origin $(DEPLOY_BRANCH) --quiet
-	@echo "Github Pages deploy was completed at `date -u`"
+	@echo "Github Pages deploy was completed at `LANG=en_US.utf8 date -u`"
 
 prepare_heroku_deployment:
 	@echo "Preparing heroku deployment..."
@@ -192,9 +192,9 @@ prepare_heroku_deployment:
 
 deploy_heroku: prepare_heroku_deployment
 	@echo "Deploying on heroku now..."
-	@cd $(DEPLOY_DIR_HEROKU); git add -A; git commit -m "docs updated at `date -u`";\
+	@cd $(DEPLOY_DIR_HEROKU); git add -A; git commit -m "docs updated at `LANG=en_US.utf8 date -u`";\
 		git push origin master --quiet
-	@echo "Heroku deployment was completed at `date -u`"
+	@echo "Heroku deployment was completed at `LANG=en_US.utf8 date -u`"
 
 
 deploy: $(DEPLOY_DEFAULT)


### PR DESCRIPTION
When the documentation is committed in Git, the commit message includes
date. However, if the person doing the deployment runs in another
locale, the commit message may end up half English, half some other
language.

This patch forces the date command to always output dates based on US
English.